### PR TITLE
proper download file name propagation

### DIFF
--- a/app/controllers/volunteer_resources_controller.rb
+++ b/app/controllers/volunteer_resources_controller.rb
@@ -4,12 +4,12 @@ class VolunteerResourcesController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @files = service_object.volunteer_resource_files
+    @files = service_object.volunteer_resource_files_by_name
   end
 
   def download
     file_data = service_object.get_file_data(params[:id])
-    file_name = service_object.class.volunteer_resource_files[params[:id]]
+    file_name = service_object.volunteer_resource_files[params[:id]]
 
     respond_to do |format|
       format.pdf do
@@ -19,7 +19,10 @@ class VolunteerResourcesController < ApplicationController
   end
 
   def show
-    @id = params[:id]
+    @file = {
+      id: params[:id],
+      name: service_object.volunteer_resource_files[params[:id]]
+    }
   end
 
   def service_object

--- a/app/views/volunteer_resources/index.html.haml
+++ b/app/views/volunteer_resources/index.html.haml
@@ -1,4 +1,4 @@
 %ul
-	- @files.each do |file|
+	- @files.each do |name, id|
 		%li
-			%a{href: url_for(controller: 'volunteer_resources', action: 'show', id: "#{file.id}")}= "#{file.name}"
+			%a{href: url_for(controller: 'volunteer_resources', action: 'show', id: "#{id}")}= "#{name}"

--- a/app/views/volunteer_resources/show.html.haml
+++ b/app/views/volunteer_resources/show.html.haml
@@ -1,5 +1,5 @@
-%object{data: url_for(controller: 'volunteer_resources', action: 'download', id: @id), type: "application/pdf", width: "100%", height: "100%"}
+%object{data: url_for(controller: 'volunteer_resources', action: 'download', id: @file[:id], file_name: @file[:name]), type: "application/pdf", width: "100%", height: "100%"}
 	%p
-		Hey there! It looks like your browser does not support PDFs. Please download the PDF to view it: <a href="#{url_for(controller: 'volunteer_resources', action: 'download', id: @id)}">Download PDF</a>.
+		Hey there! It looks like your browser does not support PDFs. Please download the PDF to view it: <a href="#{url_for(controller: 'volunteer_resources', action: 'download', id: @file[:id], file_name: @file[:name])}">Download PDF</a>.
 	%p
 		You may also want to try using Chrome as your browser. ;)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
   resources :users, only: [:edit, :show, :update]
   resources :volunteer_leads
   resources :volunteer_resources, only: [:index, :show]
-  get 'volunteer_resources/:id/download(.:format)' => 'volunteer_resources#download', defaults: {format: :pdf}
+  get 'volunteer_resources/:id/download/(:file_name)(.:format)' => 'volunteer_resources#download', defaults: {format: :pdf}
 
   # Example of regular route:
   #   get 'products/:id' => 'catalog#view'


### PR DESCRIPTION
This PR sets the file name in all of the needed places and allows for deep linking directly to docs (no need to load the list file first anymore)